### PR TITLE
Update .gitignore to ignore build folder.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 /minigzipsh
 /zlib.pc
 /configure.log
+/build
 
 .DS_Store
 .vs


### PR DESCRIPTION
Library is usually expected to be build in a folder /build at root of the library. Whenever this repository is added as submodule of another project and compiled, git shows all the generated files as changes. To suppress those git messages, we ignore the build folder in .gitignore .